### PR TITLE
Add CONUS404 and DEM Downloader Scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To play around with the jupyter notebooks, just run `pixi run nb`, and a local i
 [The DSHydro JupyterHub](https://dshydro.ce.washington.edu/jupyter/hub) is a limited-access JupyterHub running on servers at the University of Washington.
 
 1. Run `curl -fsSL https://pixi.sh/install.sh | bash` to install pixi for your user
-2. Install the data-download environment or analysis environment using `pixi install -e download-data` and `pixi install -e analysis`
+2. Install the data-download environment or analysis environment using `pixi install -e data-download` and `pixi install -e analysis`
 3. To look at the analysis notebook, install the analysis kernel with the following command: `./skagit-met/.pixi/envs/analysis/bin/python3 -m ipykernel install --user --name=skagit_analysis`
 4. Once installed, open the .ipynb file you wish to look at, and select the skagit_analyis kernel.
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -12,6 +12,8 @@ wrf = "python scripts/wrf_downloader.py"
 prism = "python scripts/prism_downloader.py"
 ornl = "python scripts/ornl_downloader.py"
 snotel = "python scripts/snotel_downloader.py"
+conus404 = "python scripts/conus404_downloader.py"
+dem = "python scripts/dem_downloader.py"
 
 # Minimal downloads for testing
 hrrr-test = "python scripts/hrrr_downloader.py --parameters 'TMP:surface,RH:2 m above ground,WIND:10 m above ground,APCP:surface:0-1 hour acc fcst,DSWRF:surface,DLWRF:surface' --startDate 2020-03-01 --endDate 2020-03-02"
@@ -20,8 +22,10 @@ wrf-test = "python scripts/wrf_downloader.py --model era5 --startDate 2020-03-01
 ornl-test = "python scripts/ornl_downloader.py --startYear 2023 --endYear 2023 --parameters prcp --gcm CNRM-ESM2-1 --climateScenario ssp585 --downscalingMethod DBCCA"
 prism-test = "python scripts/prism_downloader.py --startDate 2020-03-01 --endDate 2020-03-02"
 snotel-test = "python scripts/snotel_downloader.py --startDate 2020-03-01 --endDate 2020-03-05 --variables PRECIPITATION --frequency daily"
+conus404-test = "python scripts/conus404_downloader.py --datasetKind daily --startDate 2020-03-01 --endDate 2020-03-02 --parameters T2,Q2,RAINC,RAINNC"
+dem-test = "python scripts/dem_downloader.py --skipDownload"
 
-test-all-downloads = [{ task = "hrrr-test" }, { task = "wrf-test" }, { task = "prism-test" }, { task = "ornl-test" }, { task = "snotel-test" }]
+test-all-downloads = [{ task = "hrrr-test" }, { task = "wrf-test" }, { task = "prism-test" }, { task = "ornl-test" }, { task = "snotel-test" }, { task = "conus404-test" }, { task = "dem-test" }]
 
 # Getting atmospheric river ranges
 hrrr-2021 = "python scripts/hrrr_downloader.py --parameters 'TMP:surface,RH:2 m above ground,WIND:10 m above ground,APCP:surface:0-1 hour acc fcst,DSWRF:surface,DLWRF:surface' --startDate 2021-11-10 --endDate 2021-11-17"
@@ -53,15 +57,19 @@ flox = "*"
 xarray = "*"
 boto3 = "*"
 netcdf4 = "*"
-geopandas = ">=0.9.0,<1.0.0"
+geopandas = ">=1.1.3,<2"
 numpy = "*"
 rioxarray = "*"
 fsspec = "*"
 libgdal-netcdf = ">=3.10.2,<4"
 requests = ">=2.32.3,<3"
 aiohttp = ">=3.11.18,<4"
+s3fs = "*"
+regionmask = "*"
+elevation = "*"
 # To use demo notebooks
 ipykernel = "*"
+virtualizarr = ">=1.3.0,<2"
 
 [feature.data-download.target.osx-arm64.dependencies]
 libgfortran5 = ">=14"

--- a/scripts/conus404_downloader.py
+++ b/scripts/conus404_downloader.py
@@ -16,10 +16,11 @@ DEFAULT_GEOJSON = PROJECT_ROOT / "data/GIS/SkagitBoundary.json"
 DEFAULT_OUTPUT_DIR = PROJECT_ROOT / "data/CONUS"
 
 OSN_ENDPOINT = "https://usgs.osn.mghpcc.org"
-STORE_URLS = {
-    "daily": "s3://hytest/conus404/conus404_daily.zarr",
-    "hourly": "s3://hytest/conus404/conus404_hourly.zarr",
-    "monthly": "s3://hytest/conus404/conus404_monthly.zarr",
+STORE_URL = "s3://hytest/conus404/conus404_{}.zarr"
+DATASETS = {
+    "daily",
+    "hourly",
+    "monthly",
 }
 DEFAULT_VARS = [
     "T2",
@@ -51,7 +52,7 @@ def setupArgs() -> argparse.Namespace:
         "--datasetKind",
         default="daily",
         type=str,
-        choices=list(STORE_URLS.keys()),
+        choices=list(DATASETS),
         help="Temporal resolution of the CONUS404 dataset (daily or hourly). Default: daily.",
     )
     parser.add_argument(
@@ -129,7 +130,7 @@ def load_boundary(json_path: str) -> gpd.GeoDataFrame:
 
 def open_conus404(dataset_kind: str) -> xr.Dataset:
     """Open the CONUS404 Zarr store from the USGS OSN public endpoint."""
-    store_url = STORE_URLS[dataset_kind]
+    store_url = STORE_URL.format(dataset_kind)
     return xr.open_zarr(
         store=store_url,
         storage_options={"anon": True, "client_kwargs": {"endpoint_url": OSN_ENDPOINT}},

--- a/scripts/conus404_downloader.py
+++ b/scripts/conus404_downloader.py
@@ -19,6 +19,7 @@ OSN_ENDPOINT = "https://usgs.osn.mghpcc.org"
 STORE_URLS = {
     "daily": "s3://hytest/conus404/conus404_daily.zarr",
     "hourly": "s3://hytest/conus404/conus404_hourly.zarr",
+    "monthly": "s3://hytest/conus404/conus404_monthly.zarr",
 }
 DEFAULT_VARS = [
     "T2",

--- a/scripts/conus404_downloader.py
+++ b/scripts/conus404_downloader.py
@@ -249,15 +249,16 @@ def write_to_zarr(ds: xr.Dataset, output_path: str) -> None:
     print(f"Wrote: {output_path}")
 
 
-
 if __name__ == "__main__":
     args = setupArgs()
-    variables =  [v.strip() for v in args.parameters.split(",") if v.strip()]
+    variables = [v.strip() for v in args.parameters.split(",") if v.strip()]
 
     output_dir = args.outputDir.rstrip("/")
     os.makedirs(output_dir, exist_ok=True)
 
-    out_zarr = os.path.join(output_dir, f"conus404_skagit_{args.datasetKind}.zarr")
+    start = args.startDate.replace("-", "") if args.startDate else None
+    end = args.endDate.replace("-", "") if args.endDate else None
+    out_zarr = os.path.join(output_dir, f"conus404_{start}-{end}_{args.datasetKind}.zarr")
 
     print(f"Opening CONUS404 {args.datasetKind} dataset from OSN...")
     ds = open_conus404(args.datasetKind)

--- a/scripts/conus404_downloader.py
+++ b/scripts/conus404_downloader.py
@@ -83,13 +83,13 @@ def setupArgs() -> argparse.Namespace:
         "--geojson",
         default=str(DEFAULT_GEOJSON),
         type=str,
-        help="Path to a GeoJSON file used to spatially mask the data. Default: SkagitBoundary.json.",
+        help=f"Path to a GeoJSON file used to spatially mask the data. Default: {DEFAULT_GEOJSON}",
     )
     parser.add_argument(
         "--outputDir",
         default=str(DEFAULT_OUTPUT_DIR),
         type=str,
-        help="Directory to write the output Zarr store. Default: ../data/CONUS/.",
+        help=f"Output path for the Zarr store. Default: {DEFAULT_OUTPUT_DIR}",
     )
     return parser.parse_args()
 
@@ -249,13 +249,10 @@ def write_to_zarr(ds: xr.Dataset, output_path: str) -> None:
     print(f"Wrote: {output_path}")
 
 
-def parse_parameters(param_string: str) -> list[str]:
-    return [v.strip() for v in param_string.split(",") if v.strip()]
-
 
 if __name__ == "__main__":
     args = setupArgs()
-    variables = parse_parameters(args.parameters)
+    variables =  [v.strip() for v in args.parameters.split(",") if v.strip()]
 
     output_dir = args.outputDir.rstrip("/")
     os.makedirs(output_dir, exist_ok=True)

--- a/scripts/conus404_downloader.py
+++ b/scripts/conus404_downloader.py
@@ -10,6 +10,11 @@ import xarray as xr
 from dask.diagnostics import ProgressBar
 from shapely.geometry import LinearRing, Polygon, shape
 
+SCRIPT_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = SCRIPT_DIR.parent
+DEFAULT_GEOJSON = PROJECT_ROOT / "data/GIS/SkagitBoundary.json"
+DEFAULT_OUTPUT_DIR = PROJECT_ROOT / "data/CONUS"
+
 OSN_ENDPOINT = "https://usgs.osn.mghpcc.org"
 STORE_URLS = {
     "daily": "s3://hytest/conus404/conus404_daily.zarr",
@@ -69,15 +74,6 @@ def setupArgs() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
-        "--derivedVars",
-        action="store_true",
-        default=True,
-        help=(
-            "Compute derived variables (WS10 wind speed, PRECIP_TOT, RH, VPD) when the "
-            "required source variables are present. Enabled by default."
-        ),
-    )
-    parser.add_argument(
         "--noDerivedVars",
         dest="derivedVars",
         action="store_false",
@@ -85,13 +81,13 @@ def setupArgs() -> argparse.Namespace:
     )
     parser.add_argument(
         "--geojson",
-        default="../data/GIS/SkagitBoundary.json",
+        default=str(DEFAULT_GEOJSON),
         type=str,
         help="Path to a GeoJSON file used to spatially mask the data. Default: SkagitBoundary.json.",
     )
     parser.add_argument(
         "--outputDir",
-        default="../data/CONUS/",
+        default=str(DEFAULT_OUTPUT_DIR),
         type=str,
         help="Directory to write the output Zarr store. Default: ../data/CONUS/.",
     )

--- a/scripts/conus404_downloader.py
+++ b/scripts/conus404_downloader.py
@@ -18,270 +18,276 @@ DEFAULT_OUTPUT_DIR = PROJECT_ROOT / "data/CONUS"
 OSN_ENDPOINT = "https://usgs.osn.mghpcc.org"
 STORE_URL = "s3://hytest/conus404/conus404_{}.zarr"
 DATASETS = {
-    "daily",
-    "hourly",
-    "monthly",
+  "daily",
+  "hourly",
+  "monthly",
 }
 DEFAULT_VARS = [
-    "T2",
-    "Q2",
-    "U10",
-    "V10",
-    "PSFC",
-    "SWDNB",
-    "LWDNB",
-    "RAINC",
-    "RAINNC",
-    "SNOWNC",
-    "SMOIS",
-    "TSLB",
-    "HFX",
-    "LH",
-    "HGT",
+  "T2",
+  "Q2",
+  "U10",
+  "V10",
+  "PSFC",
+  "SWDNB",
+  "LWDNB",
+  "RAINC",
+  "RAINNC",
+  "SNOWNC",
+  "SMOIS",
+  "TSLB",
+  "HFX",
+  "LH",
+  "HGT",
 ]
 
 
 def setupArgs() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description=(
-            "Download CONUS404 data from the USGS OSN public S3 endpoint, clip to a geographic region, "
-            "compute derived variables, and save as Zarr. "
-        )
+  parser = argparse.ArgumentParser(
+    description=(
+      "Download CONUS404 data from the USGS OSN public S3 endpoint, clip to a geographic region, "
+      "compute derived variables, and save as Zarr. "
     )
-    parser.add_argument(
-        "--datasetKind",
-        default="daily",
-        type=str,
-        choices=list(DATASETS),
-        help="Temporal resolution of the CONUS404 dataset (daily or hourly). Default: daily.",
-    )
-    parser.add_argument(
-        "--startDate",
-        default=None,
-        type=str,
-        help="Start date (inclusive) to subset, e.g. 2014-10-01. Defaults to full dataset range.",
-    )
-    parser.add_argument(
-        "--endDate",
-        default=None,
-        type=str,
-        help="End date (inclusive) to subset, e.g. 2023-12-31. Defaults to full dataset range.",
-    )
-    parser.add_argument(
-        "--parameters",
-        type=str,
-        default=",".join(DEFAULT_VARS),
-        help=(
-            f"Comma-separated list of CONUS404 variables to keep. Defaults to: {','.join(DEFAULT_VARS)}"
-        ),
-    )
-    parser.add_argument(
-        "--noDerivedVars",
-        dest="derivedVars",
-        action="store_false",
-        help="Disable computation of derived variables.",
-    )
-    parser.add_argument(
-        "--geojson",
-        default=str(DEFAULT_GEOJSON),
-        type=str,
-        help=f"Path to a GeoJSON file used to spatially mask the data. Default: {DEFAULT_GEOJSON}",
-    )
-    parser.add_argument(
-        "--outputDir",
-        default=str(DEFAULT_OUTPUT_DIR),
-        type=str,
-        help=f"Output path for the Zarr store. Default: {DEFAULT_OUTPUT_DIR}",
-    )
-    return parser.parse_args()
+  )
+  parser.add_argument(
+    "--datasetKind",
+    default="daily",
+    type=str,
+    choices=list(DATASETS),
+    help="Temporal resolution of the CONUS404 dataset (daily or hourly). Default: daily.",
+  )
+  parser.add_argument(
+    "--startDate",
+    default=None,
+    type=str,
+    help="Start date (inclusive) to subset, e.g. 2014-10-01. Defaults to full dataset range.",
+  )
+  parser.add_argument(
+    "--endDate",
+    default=None,
+    type=str,
+    help="End date (inclusive) to subset, e.g. 2023-12-31. Defaults to full dataset range.",
+  )
+  parser.add_argument(
+    "--parameters",
+    type=str,
+    default=",".join(DEFAULT_VARS),
+    help=(
+      f"Comma-separated list of CONUS404 variables to keep. Defaults to: {','.join(DEFAULT_VARS)}"
+    ),
+  )
+  parser.add_argument(
+    "--noDerivedVars",
+    dest="derivedVars",
+    action="store_false",
+    help="Disable computation of derived variables.",
+  )
+  parser.add_argument(
+    "--geojson",
+    default=str(DEFAULT_GEOJSON),
+    type=str,
+    help=f"Path to a GeoJSON file used to spatially mask the data. Default: {DEFAULT_GEOJSON}",
+  )
+  parser.add_argument(
+    "--outputDir",
+    default=str(DEFAULT_OUTPUT_DIR),
+    type=str,
+    help=f"Output path for the Zarr store. Default: {DEFAULT_OUTPUT_DIR}",
+  )
+  return parser.parse_args()
 
 
 def load_boundary(json_path: str) -> gpd.GeoDataFrame:
-    """Load a boundary GeoJSON into a GeoDataFrame."""
-    with open(json_path) as f:
-        obj = json.load(f)
+  """Load a boundary GeoJSON into a GeoDataFrame."""
+  with open(json_path) as f:
+    obj = json.load(f)
 
-    basin_geom = None
-    if isinstance(obj, dict) and "type" in obj:
-        try:
-            if obj["type"] == "FeatureCollection":
-                geom = shape(obj["features"][0]["geometry"])
-            elif obj["type"] == "Feature":
-                geom = shape(obj["geometry"])
-            else:
-                geom = shape(obj)
-            basin_geom = geom
-        except Exception:
-            pass
+  basin_geom = None
+  if isinstance(obj, dict) and "type" in obj:
+    try:
+      if obj["type"] == "FeatureCollection":
+        geom = shape(obj["features"][0]["geometry"])
+      elif obj["type"] == "Feature":
+        geom = shape(obj["geometry"])
+      else:
+        geom = shape(obj)
+      basin_geom = geom
+    except Exception:
+      pass
 
-    # Fallback: {"lon": [...], "lat": [...]}
-    if basin_geom is None and isinstance(obj, dict) and "lon" in obj and "lat" in obj:
-        coords = list(zip(obj["lon"], obj["lat"]))
-        # Closes the polygon ring
-        if coords[0] != coords[-1]:
-            coords.append(coords[0])
-        basin_geom = Polygon(LinearRing(coords))
+  # Fallback: {"lon": [...], "lat": [...]}
+  if basin_geom is None and isinstance(obj, dict) and "lon" in obj and "lat" in obj:
+    coords = list(zip(obj["lon"], obj["lat"]))
+    # Closes the polygon ring
+    if coords[0] != coords[-1]:
+      coords.append(coords[0])
+    basin_geom = Polygon(LinearRing(coords))
 
-    if basin_geom is None:
-        raise ValueError('Invalid boundary file format. Must be GeoJSON or {"lon": [...], "lat": [...]}.')
+  if basin_geom is None:
+    raise ValueError(
+      'Invalid boundary file format. Must be GeoJSON or {"lon": [...], "lat": [...]}.'
+    )
 
-    return gpd.GeoDataFrame({"name": ["boundary"]}, geometry=[basin_geom], crs="EPSG:4326")
+  return gpd.GeoDataFrame({"name": ["boundary"]}, geometry=[basin_geom], crs="EPSG:4326")
 
 
 def open_conus404(dataset_kind: str) -> xr.Dataset:
-    """Open the CONUS404 Zarr store from the USGS OSN public endpoint."""
-    store_url = STORE_URL.format(dataset_kind)
-    return xr.open_zarr(
-        store=store_url,
-        storage_options={"anon": True, "client_kwargs": {"endpoint_url": OSN_ENDPOINT}},
-        consolidated=True,
+  """Open the CONUS404 Zarr store from the USGS OSN public endpoint."""
+  store_url = STORE_URL.format(dataset_kind)
+  return xr.open_zarr(
+    store=store_url,
+    storage_options={"anon": True, "client_kwargs": {"endpoint_url": OSN_ENDPOINT}},
+    consolidated=True,
+  )
+
+
+def subset_dataset(
+  ds: xr.Dataset, start_date: str | None, end_date: str | None, variables: list[str]
+) -> xr.Dataset:
+  """Slice time and filter to requested variables."""
+  if start_date or end_date:
+    ds = ds.sel(time=slice(start_date, end_date))
+
+  available = set(ds.data_vars)
+
+  if missing := [v for v in variables if v not in available]:
+    print(f"Warning: variables not found in dataset and will be ignored: {missing}")
+
+  keep = [v for v in variables if v in available]
+  if not keep:
+    raise ValueError(
+      f"None of the requested variables {variables} are available. Available variables: {sorted(available)[:25]}"
     )
 
-
-def subset_dataset(ds: xr.Dataset, start_date: str | None, end_date: str | None, variables: list[str]) -> xr.Dataset:
-    """Slice time and filter to requested variables."""
-    if start_date or end_date:
-        ds = ds.sel(time=slice(start_date, end_date))
-
-    available = set(ds.data_vars)
-
-    if missing := [v for v in variables if v not in available]:
-        print(f"Warning: variables not found in dataset and will be ignored: {missing}")
-
-    keep = [v for v in variables if v in available]
-    if not keep:
-        raise ValueError(
-            f"None of the requested variables {variables} are available. Available variables: {sorted(available)[:25]}"
-        )
-
-    return ds[keep]
+  return ds[keep]
 
 
 def get_spatial_dims(ds: xr.Dataset) -> tuple[xr.DataArray, xr.DataArray, tuple[str, str]]:
-    """Locate 2D lat/lon coordinate arrays and return them together with their dimension names."""
-    for lat_name, lon_name in [("lat", "lon"), ("XLAT", "XLONG"), ("latitude", "longitude")]:
-        if lat_name in ds and lon_name in ds:
-            da_lat = ds[lat_name]
-            da_lon = ds[lon_name]
-            return da_lat, da_lon, tuple(da_lat.dims)
-    raise KeyError(
-        "Could not find lat/lon coordinate variables in dataset. "
-        f"Available variables: {list(ds.coords)}"
+  """Locate 2D lat/lon coordinate arrays and return them together with their dimension names."""
+  for lat_name, lon_name in [("lat", "lon"), ("XLAT", "XLONG"), ("latitude", "longitude")]:
+    if lat_name in ds and lon_name in ds:
+      da_lat = ds[lat_name]
+      da_lon = ds[lon_name]
+      return da_lat, da_lon, tuple(da_lat.dims)
+  raise KeyError(
+    "Could not find lat/lon coordinate variables in dataset. "
+    f"Available variables: {list(ds.coords)}"
+  )
+
+
+def apply_spatial_mask(
+  ds: xr.Dataset, gdf: gpd.GeoDataFrame, da_lon: xr.DataArray, da_lat: xr.DataArray
+) -> xr.Dataset:
+  """Mask the dataset to the boundary polygon using regionmask."""
+  gdf_exploded = gdf.explode(ignore_index=True)
+
+  if hasattr(regionmask.Regions, "from_geopandas"):
+    regions = regionmask.Regions.from_geopandas(gdf_exploded, names="name")
+  else:
+    outlines = list(filter(None, gdf_exploded.geometry))
+    regions = regionmask.Regions(
+      outlines=outlines,
+      names=["boundary"] * len(outlines),
+      numbers=list(range(len(outlines))),
+      name="boundary",
     )
 
-
-def apply_spatial_mask(ds: xr.Dataset, gdf: gpd.GeoDataFrame, da_lon: xr.DataArray, da_lat: xr.DataArray) -> xr.Dataset:
-    """Mask the dataset to the boundary polygon using regionmask."""
-    gdf_exploded = gdf.explode(ignore_index=True)
-
-    if hasattr(regionmask.Regions, "from_geopandas"):
-        regions = regionmask.Regions.from_geopandas(gdf_exploded, names="name")
-    else:
-        outlines = list(filter(None, gdf_exploded.geometry))
-        regions = regionmask.Regions(
-            outlines=outlines,
-            names=["boundary"] * len(outlines),
-            numbers=list(range(len(outlines))),
-            name="boundary",
-        )
-
-    mask = regions.mask(da_lon, da_lat)
-    return ds.where(mask.notnull())
+  mask = regions.mask(da_lon, da_lat)
+  return ds.where(mask.notnull())
 
 
 def compute_derived_vars(ds: xr.Dataset) -> xr.Dataset:
-    """Add derived variables (WS10, PRECIP_TOT, RH, VPD) when source variables are available."""
-    # Compute WS10
-    if {"U10", "V10"} <= set(ds.data_vars):
-        ds["WS10"] = (ds["U10"] ** 2 + ds["V10"] ** 2) ** 0.5
-        ds["WS10"].attrs.update(units="m s-1", long_name="10 m wind speed")
+  """Add derived variables (WS10, PRECIP_TOT, RH, VPD) when source variables are available."""
+  # Compute WS10
+  if {"U10", "V10"} <= set(ds.data_vars):
+    ds["WS10"] = (ds["U10"] ** 2 + ds["V10"] ** 2) ** 0.5
+    ds["WS10"].attrs.update(units="m s-1", long_name="10 m wind speed")
 
-    # Compute PRECIP_TOT
-    has_rain = {"RAINC", "RAINNC"} <= set(ds.data_vars)
-    has_snow = "SNOWNC" in ds.data_vars
-    if has_rain or has_snow:
-        pieces = []
-        if has_rain:
-            pieces.append(ds["RAINC"] + ds["RAINNC"])
-        if has_snow:
-            pieces.append(ds["SNOWNC"])
-        ds["PRECIP_TOT"] = sum(pieces)
-        ds["PRECIP_TOT"].attrs.update(units="mm", long_name="Total precipitation (rain+snow)")
+  # Compute PRECIP_TOT
+  has_rain = {"RAINC", "RAINNC"} <= set(ds.data_vars)
+  has_snow = "SNOWNC" in ds.data_vars
+  if has_rain or has_snow:
+    pieces = []
+    if has_rain:
+      pieces.append(ds["RAINC"] + ds["RAINNC"])
+    if has_snow:
+      pieces.append(ds["SNOWNC"])
+    ds["PRECIP_TOT"] = sum(pieces)
+    ds["PRECIP_TOT"].attrs.update(units="mm", long_name="Total precipitation (rain+snow)")
 
-    # Compute RH and VPD
-    if {"T2", "Q2", "PSFC"} <= set(ds.data_vars):
-        t_c = ds["T2"] - 273.15
-        p_kpa = ds["PSFC"] / 1000.0
-        q = ds["Q2"]
-        es_kpa = 0.6108 * np.exp((17.27 * t_c) / (t_c + 237.3))
-        e_kpa = (q * p_kpa) / (0.622 + 0.378 * q)
-        ds["RH"] = (e_kpa / es_kpa).clip(0, 1) * 100.0
-        ds["VPD"] = (es_kpa - e_kpa).clip(min=0)
-        ds["RH"].attrs.update(units="%", long_name="Relative Humidity")
-        ds["VPD"].attrs.update(units="kPa", long_name="Vapor Pressure Deficit")
+  # Compute RH and VPD
+  if {"T2", "Q2", "PSFC"} <= set(ds.data_vars):
+    t_c = ds["T2"] - 273.15
+    p_kpa = ds["PSFC"] / 1000.0
+    q = ds["Q2"]
+    es_kpa = 0.6108 * np.exp((17.27 * t_c) / (t_c + 237.3))
+    e_kpa = (q * p_kpa) / (0.622 + 0.378 * q)
+    ds["RH"] = (e_kpa / es_kpa).clip(0, 1) * 100.0
+    ds["VPD"] = (es_kpa - e_kpa).clip(min=0)
+    ds["RH"].attrs.update(units="%", long_name="Relative Humidity")
+    ds["VPD"].attrs.update(units="kPa", long_name="Vapor Pressure Deficit")
 
-    return ds
+  return ds
 
 
 def rechunk_dataset(ds: xr.Dataset, spatial_dims: tuple[str, str], dataset_kind: str) -> xr.Dataset:
-    """Apply appropriate chunking and strip stale encoding chunks."""
-    time_chunk = 24 * 7 if dataset_kind == "hourly" else 30
-    chunks = {"time": time_chunk, spatial_dims[0]: 300, spatial_dims[1]: 300}
-    ds = ds.chunk(chunks)
+  """Apply appropriate chunking and strip stale encoding chunks."""
+  time_chunk = 24 * 7 if dataset_kind == "hourly" else 30
+  chunks = {"time": time_chunk, spatial_dims[0]: 300, spatial_dims[1]: 300}
+  ds = ds.chunk(chunks)
 
-    # Remove bad encodings (prevents overlapping chunk error)
-    for v in ds.variables:
-        ds[v].encoding.pop("chunks", None)
+  # Remove bad encodings (prevents overlapping chunk error)
+  for v in ds.variables:
+    ds[v].encoding.pop("chunks", None)
 
-    # Re-chunk the coordinate arrays
-    coord_chunks = {spatial_dims[0]: 300, spatial_dims[1]: 300}
-    for coord in ("lat", "lon", "XLAT", "XLONG", "latitude", "longitude"):
-        if coord in ds:
-            ds[coord] = ds[coord].chunk(coord_chunks)
+  # Re-chunk the coordinate arrays
+  coord_chunks = {spatial_dims[0]: 300, spatial_dims[1]: 300}
+  for coord in ("lat", "lon", "XLAT", "XLONG", "latitude", "longitude"):
+    if coord in ds:
+      ds[coord] = ds[coord].chunk(coord_chunks)
 
-    return ds
+  return ds
 
 
 def write_to_zarr(ds: xr.Dataset, output_path: str) -> None:
-    """Write the dataset to a Zarr v2 store."""
-    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
-    print(f"Writing to {output_path} ...")
-    with ProgressBar():
-        ds.to_zarr(output_path, mode="w", consolidated=True, zarr_version=2)
-    print(f"Wrote: {output_path}")
+  """Write the dataset to a Zarr v2 store."""
+  Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+  print(f"Writing to {output_path} ...")
+  with ProgressBar():
+    ds.to_zarr(output_path, mode="w", consolidated=True, zarr_version=2)
+  print(f"Wrote: {output_path}")
 
 
 if __name__ == "__main__":
-    args = setupArgs()
-    variables = [v.strip() for v in args.parameters.split(",") if v.strip()]
+  args = setupArgs()
+  variables = [v.strip() for v in args.parameters.split(",") if v.strip()]
 
-    output_dir = args.outputDir.rstrip("/")
-    os.makedirs(output_dir, exist_ok=True)
+  output_dir = args.outputDir.rstrip("/")
+  os.makedirs(output_dir, exist_ok=True)
 
-    start = args.startDate.replace("-", "") if args.startDate else None
-    end = args.endDate.replace("-", "") if args.endDate else None
-    out_zarr = os.path.join(output_dir, f"conus404_{start}-{end}_{args.datasetKind}.zarr")
+  start = args.startDate.replace("-", "") if args.startDate else None
+  end = args.endDate.replace("-", "") if args.endDate else None
+  out_zarr = os.path.join(output_dir, f"conus404_{start}-{end}_{args.datasetKind}.zarr")
 
-    print(f"Opening CONUS404 {args.datasetKind} dataset from OSN...")
-    ds = open_conus404(args.datasetKind)
+  print(f"Opening CONUS404 {args.datasetKind} dataset from OSN...")
+  ds = open_conus404(args.datasetKind)
 
-    print("Subsetting time range and variables...")
-    ds = subset_dataset(ds, args.startDate, args.endDate, variables)
+  print("Subsetting time range and variables...")
+  ds = subset_dataset(ds, args.startDate, args.endDate, variables)
 
-    print("Locating spatial coordinate arrays...")
-    da_lat, da_lon, spatial_dims = get_spatial_dims(ds)
+  print("Locating spatial coordinate arrays...")
+  da_lat, da_lon, spatial_dims = get_spatial_dims(ds)
 
-    print(f"Loading boundary from {args.geojson}...")
-    gdf = load_boundary(args.geojson)
+  print(f"Loading boundary from {args.geojson}...")
+  gdf = load_boundary(args.geojson)
 
-    print("Applying spatial mask...")
-    ds = apply_spatial_mask(ds, gdf, da_lon, da_lat)
+  print("Applying spatial mask...")
+  ds = apply_spatial_mask(ds, gdf, da_lon, da_lat)
 
-    if args.derivedVars:
-        print("Computing derived variables...")
-        ds = compute_derived_vars(ds)
+  if args.derivedVars:
+    print("Computing derived variables...")
+    ds = compute_derived_vars(ds)
 
-    print("Rechunking dataset...")
-    ds = rechunk_dataset(ds, spatial_dims, args.datasetKind)
+  print("Rechunking dataset...")
+  ds = rechunk_dataset(ds, spatial_dims, args.datasetKind)
 
-    write_to_zarr(ds, out_zarr)
+  write_to_zarr(ds, out_zarr)

--- a/scripts/conus404_downloader.py
+++ b/scripts/conus404_downloader.py
@@ -1,0 +1,291 @@
+import argparse
+import json
+import os
+from pathlib import Path
+
+import geopandas as gpd
+import numpy as np
+import regionmask
+import xarray as xr
+from dask.diagnostics import ProgressBar
+from shapely.geometry import LinearRing, Polygon, shape
+
+OSN_ENDPOINT = "https://usgs.osn.mghpcc.org"
+STORE_URLS = {
+    "daily": "s3://hytest/conus404/conus404_daily.zarr",
+    "hourly": "s3://hytest/conus404/conus404_hourly.zarr",
+}
+DEFAULT_VARS = [
+    "T2",
+    "Q2",
+    "U10",
+    "V10",
+    "PSFC",
+    "SWDNB",
+    "LWDNB",
+    "RAINC",
+    "RAINNC",
+    "SNOWNC",
+    "SMOIS",
+    "TSLB",
+    "HFX",
+    "LH",
+    "HGT",
+]
+
+
+def setupArgs() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Download CONUS404 data from the USGS OSN public S3 endpoint, clip to a geographic region, "
+            "compute derived variables, and save as Zarr. "
+        )
+    )
+    parser.add_argument(
+        "--datasetKind",
+        default="daily",
+        type=str,
+        choices=list(STORE_URLS.keys()),
+        help="Temporal resolution of the CONUS404 dataset (daily or hourly). Default: daily.",
+    )
+    parser.add_argument(
+        "--startDate",
+        default=None,
+        type=str,
+        help="Start date (inclusive) to subset, e.g. 2014-10-01. Defaults to full dataset range.",
+    )
+    parser.add_argument(
+        "--endDate",
+        default=None,
+        type=str,
+        help="End date (inclusive) to subset, e.g. 2023-12-31. Defaults to full dataset range.",
+    )
+    parser.add_argument(
+        "--parameters",
+        type=str,
+        default=",".join(DEFAULT_VARS),
+        help=(
+            f"Comma-separated list of CONUS404 variables to keep. Defaults to: {','.join(DEFAULT_VARS)}"
+        ),
+    )
+    parser.add_argument(
+        "--derivedVars",
+        action="store_true",
+        default=True,
+        help=(
+            "Compute derived variables (WS10 wind speed, PRECIP_TOT, RH, VPD) when the "
+            "required source variables are present. Enabled by default."
+        ),
+    )
+    parser.add_argument(
+        "--noDerivedVars",
+        dest="derivedVars",
+        action="store_false",
+        help="Disable computation of derived variables.",
+    )
+    parser.add_argument(
+        "--geojson",
+        default="../data/GIS/SkagitBoundary.json",
+        type=str,
+        help="Path to a GeoJSON file used to spatially mask the data. Default: SkagitBoundary.json.",
+    )
+    parser.add_argument(
+        "--outputDir",
+        default="../data/CONUS/",
+        type=str,
+        help="Directory to write the output Zarr store. Default: ../data/CONUS/.",
+    )
+    return parser.parse_args()
+
+
+def load_boundary(json_path: str) -> gpd.GeoDataFrame:
+    """Load a boundary GeoJSON into a GeoDataFrame."""
+    with open(json_path) as f:
+        obj = json.load(f)
+
+    basin_geom = None
+    if isinstance(obj, dict) and "type" in obj:
+        try:
+            if obj["type"] == "FeatureCollection":
+                geom = shape(obj["features"][0]["geometry"])
+            elif obj["type"] == "Feature":
+                geom = shape(obj["geometry"])
+            else:
+                geom = shape(obj)
+            basin_geom = geom
+        except Exception:
+            pass
+
+    # Fallback: {"lon": [...], "lat": [...]}
+    if basin_geom is None and isinstance(obj, dict) and "lon" in obj and "lat" in obj:
+        coords = list(zip(obj["lon"], obj["lat"]))
+        # Closes the polygon ring
+        if coords[0] != coords[-1]:
+            coords.append(coords[0])
+        basin_geom = Polygon(LinearRing(coords))
+
+    if basin_geom is None:
+        raise ValueError('Invalid boundary file format. Must be GeoJSON or {"lon": [...], "lat": [...]}.')
+
+    return gpd.GeoDataFrame({"name": ["boundary"]}, geometry=[basin_geom], crs="EPSG:4326")
+
+
+def open_conus404(dataset_kind: str) -> xr.Dataset:
+    """Open the CONUS404 Zarr store from the USGS OSN public endpoint."""
+    store_url = STORE_URLS[dataset_kind]
+    return xr.open_zarr(
+        store=store_url,
+        storage_options={"anon": True, "client_kwargs": {"endpoint_url": OSN_ENDPOINT}},
+        consolidated=True,
+    )
+
+
+def subset_dataset(ds: xr.Dataset, start_date: str | None, end_date: str | None, variables: list[str]) -> xr.Dataset:
+    """Slice time and filter to requested variables."""
+    if start_date or end_date:
+        ds = ds.sel(time=slice(start_date, end_date))
+
+    available = set(ds.data_vars)
+
+    if missing := [v for v in variables if v not in available]:
+        print(f"Warning: variables not found in dataset and will be ignored: {missing}")
+
+    keep = [v for v in variables if v in available]
+    if not keep:
+        raise ValueError(
+            f"None of the requested variables {variables} are available. Available variables: {sorted(available)[:25]}"
+        )
+
+    return ds[keep]
+
+
+def get_spatial_dims(ds: xr.Dataset) -> tuple[xr.DataArray, xr.DataArray, tuple[str, str]]:
+    """Locate 2D lat/lon coordinate arrays and return them together with their dimension names."""
+    for lat_name, lon_name in [("lat", "lon"), ("XLAT", "XLONG"), ("latitude", "longitude")]:
+        if lat_name in ds and lon_name in ds:
+            da_lat = ds[lat_name]
+            da_lon = ds[lon_name]
+            return da_lat, da_lon, tuple(da_lat.dims)
+    raise KeyError(
+        "Could not find lat/lon coordinate variables in dataset. "
+        f"Available variables: {list(ds.coords)}"
+    )
+
+
+def apply_spatial_mask(ds: xr.Dataset, gdf: gpd.GeoDataFrame, da_lon: xr.DataArray, da_lat: xr.DataArray) -> xr.Dataset:
+    """Mask the dataset to the boundary polygon using regionmask."""
+    gdf_exploded = gdf.explode(ignore_index=True)
+
+    if hasattr(regionmask.Regions, "from_geopandas"):
+        regions = regionmask.Regions.from_geopandas(gdf_exploded, names="name")
+    else:
+        outlines = list(filter(None, gdf_exploded.geometry))
+        regions = regionmask.Regions(
+            outlines=outlines,
+            names=["boundary"] * len(outlines),
+            numbers=list(range(len(outlines))),
+            name="boundary",
+        )
+
+    mask = regions.mask(da_lon, da_lat)
+    return ds.where(mask.notnull())
+
+
+def compute_derived_vars(ds: xr.Dataset) -> xr.Dataset:
+    """Add derived variables (WS10, PRECIP_TOT, RH, VPD) when source variables are available."""
+    # Compute WS10
+    if {"U10", "V10"} <= set(ds.data_vars):
+        ds["WS10"] = (ds["U10"] ** 2 + ds["V10"] ** 2) ** 0.5
+        ds["WS10"].attrs.update(units="m s-1", long_name="10 m wind speed")
+
+    # Compute PRECIP_TOT
+    has_rain = {"RAINC", "RAINNC"} <= set(ds.data_vars)
+    has_snow = "SNOWNC" in ds.data_vars
+    if has_rain or has_snow:
+        pieces = []
+        if has_rain:
+            pieces.append(ds["RAINC"] + ds["RAINNC"])
+        if has_snow:
+            pieces.append(ds["SNOWNC"])
+        ds["PRECIP_TOT"] = sum(pieces)
+        ds["PRECIP_TOT"].attrs.update(units="mm", long_name="Total precipitation (rain+snow)")
+
+    # Compute RH and VPD
+    if {"T2", "Q2", "PSFC"} <= set(ds.data_vars):
+        t_c = ds["T2"] - 273.15
+        p_kpa = ds["PSFC"] / 1000.0
+        q = ds["Q2"]
+        es_kpa = 0.6108 * np.exp((17.27 * t_c) / (t_c + 237.3))
+        e_kpa = (q * p_kpa) / (0.622 + 0.378 * q)
+        ds["RH"] = (e_kpa / es_kpa).clip(0, 1) * 100.0
+        ds["VPD"] = (es_kpa - e_kpa).clip(min=0)
+        ds["RH"].attrs.update(units="%", long_name="Relative Humidity")
+        ds["VPD"].attrs.update(units="kPa", long_name="Vapor Pressure Deficit")
+
+    return ds
+
+
+def rechunk_dataset(ds: xr.Dataset, spatial_dims: tuple[str, str], dataset_kind: str) -> xr.Dataset:
+    """Apply appropriate chunking and strip stale encoding chunks."""
+    time_chunk = 24 * 7 if dataset_kind == "hourly" else 30
+    chunks = {"time": time_chunk, spatial_dims[0]: 300, spatial_dims[1]: 300}
+    ds = ds.chunk(chunks)
+
+    # Remove bad encodings (prevents overlapping chunk error)
+    for v in ds.variables:
+        ds[v].encoding.pop("chunks", None)
+
+    # Re-chunk the coordinate arrays
+    coord_chunks = {spatial_dims[0]: 300, spatial_dims[1]: 300}
+    for coord in ("lat", "lon", "XLAT", "XLONG", "latitude", "longitude"):
+        if coord in ds:
+            ds[coord] = ds[coord].chunk(coord_chunks)
+
+    return ds
+
+
+def write_to_zarr(ds: xr.Dataset, output_path: str) -> None:
+    """Write the dataset to a Zarr v2 store."""
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    print(f"Writing to {output_path} ...")
+    with ProgressBar():
+        ds.to_zarr(output_path, mode="w", consolidated=True, zarr_version=2)
+    print(f"Wrote: {output_path}")
+
+
+def parse_parameters(param_string: str) -> list[str]:
+    return [v.strip() for v in param_string.split(",") if v.strip()]
+
+
+if __name__ == "__main__":
+    args = setupArgs()
+    variables = parse_parameters(args.parameters)
+
+    output_dir = args.outputDir.rstrip("/")
+    os.makedirs(output_dir, exist_ok=True)
+
+    out_zarr = os.path.join(output_dir, f"conus404_skagit_{args.datasetKind}.zarr")
+
+    print(f"Opening CONUS404 {args.datasetKind} dataset from OSN...")
+    ds = open_conus404(args.datasetKind)
+
+    print("Subsetting time range and variables...")
+    ds = subset_dataset(ds, args.startDate, args.endDate, variables)
+
+    print("Locating spatial coordinate arrays...")
+    da_lat, da_lon, spatial_dims = get_spatial_dims(ds)
+
+    print(f"Loading boundary from {args.geojson}...")
+    gdf = load_boundary(args.geojson)
+
+    print("Applying spatial mask...")
+    ds = apply_spatial_mask(ds, gdf, da_lon, da_lat)
+
+    if args.derivedVars:
+        print("Computing derived variables...")
+        ds = compute_derived_vars(ds)
+
+    print("Rechunking dataset...")
+    ds = rechunk_dataset(ds, spatial_dims, args.datasetKind)
+
+    write_to_zarr(ds, out_zarr)

--- a/scripts/dem_downloader.py
+++ b/scripts/dem_downloader.py
@@ -14,121 +14,123 @@ DEFAULT_GEOJSON = PROJECT_ROOT / "data/GIS/SkagitBoundary.json"
 
 
 def setupArgs() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description=(
-            "Downloads an SRTM 90 m Digital Elevation Model (DEM) for a bounding box, "
-            "clips it to a watershed boundary, and saves the result as a GeoTIFF."
-        )
+  parser = argparse.ArgumentParser(
+    description=(
+      "Downloads an SRTM 90 m Digital Elevation Model (DEM) for a bounding box, "
+      "clips it to a watershed boundary, and saves the result as a GeoTIFF."
     )
-    parser.add_argument(
-        "--bounds",
-        type=float,
-        nargs=4,
-        metavar=("MIN_LON", "MIN_LAT", "MAX_LON", "MAX_LAT"),
-        default=None,
-        help=(
-            "Bounding box for DEM download as four floats: minLon minLat maxLon maxLat. "
-            "If omitted, bounds are computed from --geojson."
-        ),
-    )
-    parser.add_argument(
-        "--outputFile",
-        default=str(DEFAULT_OUTPUT),
-        type=str,
-        help=f"Output path for the raw (unclipped) DEM GeoTIFF. Default: {DEFAULT_OUTPUT}",
-    )
-    parser.add_argument(
-        "--clippedOutputFile",
-        default=None,
-        type=str,
-        help=(
-            "Output path for the clipped DEM GeoTIFF. Defaults to <outputFile stem>_clipped.tif next to the outputFile."
-        ),
-    )
-    parser.add_argument(
-        "--geojson",
-        default=str(DEFAULT_GEOJSON),
-        type=str,
-        help=f"Path to a GeoJSON file used to spatially mask the data. Default: {DEFAULT_GEOJSON}",
-    )
-    parser.add_argument(
-        "--skipDownload",
-        action="store_true",
-        default=False,
-        help="Skip downloading a new DEM if the output file already exists.",
-    )
-    return parser.parse_args()
+  )
+  parser.add_argument(
+    "--bounds",
+    type=float,
+    nargs=4,
+    metavar=("MIN_LON", "MIN_LAT", "MAX_LON", "MAX_LAT"),
+    default=None,
+    help=(
+      "Bounding box for DEM download as four floats: minLon minLat maxLon maxLat. "
+      "If omitted, bounds are computed from --geojson."
+    ),
+  )
+  parser.add_argument(
+    "--outputFile",
+    default=str(DEFAULT_OUTPUT),
+    type=str,
+    help=f"Output path for the raw (unclipped) DEM GeoTIFF. Default: {DEFAULT_OUTPUT}",
+  )
+  parser.add_argument(
+    "--clippedOutputFile",
+    default=None,
+    type=str,
+    help=(
+      "Output path for the clipped DEM GeoTIFF. Defaults to <outputFile stem>_clipped.tif next to the outputFile."
+    ),
+  )
+  parser.add_argument(
+    "--geojson",
+    default=str(DEFAULT_GEOJSON),
+    type=str,
+    help=f"Path to a GeoJSON file used to spatially mask the data. Default: {DEFAULT_GEOJSON}",
+  )
+  parser.add_argument(
+    "--skipDownload",
+    action="store_true",
+    default=False,
+    help="Skip downloading a new DEM if the output file already exists.",
+  )
+  return parser.parse_args()
 
 
-def bounds_from_geojson(geojson_path: str, buffer_deg: float = 0.0) -> tuple[float, float, float, float]:
-    gdf = gpd.read_file(geojson_path)
+def bounds_from_geojson(
+  geojson_path: str, buffer_deg: float = 0.0
+) -> tuple[float, float, float, float]:
+  gdf = gpd.read_file(geojson_path)
 
-    # Ensure lon/lat degree bounds are interpreted consistently
-    if gdf.crs is None:
-        gdf = gdf.set_crs("EPSG:4326")
-    elif gdf.crs.to_string() != "EPSG:4326":
-        gdf = gdf.to_crs("EPSG:4326")
+  # Ensure lon/lat degree bounds are interpreted consistently
+  if gdf.crs is None:
+    gdf = gdf.set_crs("EPSG:4326")
+  elif gdf.crs.to_string() != "EPSG:4326":
+    gdf = gdf.to_crs("EPSG:4326")
 
-    minx, miny, maxx, maxy = gdf.total_bounds
-    return (minx - buffer_deg, miny - buffer_deg, maxx + buffer_deg, maxy + buffer_deg)
+  minx, miny, maxx, maxy = gdf.total_bounds
+  return (minx - buffer_deg, miny - buffer_deg, maxx + buffer_deg, maxy + buffer_deg)
 
 
 def download_dem(bounds: tuple[float, float, float, float], output_file: str) -> None:
-    """Download SRTM 90 m tiles for the given bounding box and merge into a single GeoTIFF."""
-    os.makedirs(os.path.dirname(os.path.abspath(output_file)), exist_ok=True)
-    print(f"Downloading SRTM 90 m DEM for bounds {bounds} -> {output_file}")
-    elevation.clip(bounds=bounds, output=output_file)
-    print("Download complete.")
+  """Download SRTM 90 m tiles for the given bounding box and merge into a single GeoTIFF."""
+  os.makedirs(os.path.dirname(os.path.abspath(output_file)), exist_ok=True)
+  print(f"Downloading SRTM 90 m DEM for bounds {bounds} -> {output_file}")
+  elevation.clip(bounds=bounds, output=output_file)
+  print("Download complete.")
 
 
 def clip_dem_to_boundary(dem_path: str, geojson_path: str, clipped_output: str) -> xr.DataArray:
-    """Open the DEM with rioxarray and clip it to the watershed polygon."""
-    boundary = gpd.read_file(geojson_path)
-    dem = rioxarray.open_rasterio(dem_path, masked=True)
+  """Open the DEM with rioxarray and clip it to the watershed polygon."""
+  boundary = gpd.read_file(geojson_path)
+  dem = rioxarray.open_rasterio(dem_path, masked=True)
 
-    # Ensure the boundary CRS matches the DEM CRS before clipping
-    if boundary.crs is None:
-        print("Warning: boundary GeoJSON has no CRS; assuming EPSG:4326.")
-        boundary = boundary.set_crs("EPSG:4326")
-    if dem.rio.crs is not None and boundary.crs != dem.rio.crs:
-        boundary = boundary.to_crs(dem.rio.crs)
+  # Ensure the boundary CRS matches the DEM CRS before clipping
+  if boundary.crs is None:
+    print("Warning: boundary GeoJSON has no CRS; assuming EPSG:4326.")
+    boundary = boundary.set_crs("EPSG:4326")
+  if dem.rio.crs is not None and boundary.crs != dem.rio.crs:
+    boundary = boundary.to_crs(dem.rio.crs)
 
-    clipped = dem.rio.clip(boundary.geometry)
+  clipped = dem.rio.clip(boundary.geometry)
 
-    os.makedirs(os.path.dirname(os.path.abspath(clipped_output)), exist_ok=True)
-    clipped.rio.to_raster(clipped_output)
-    print(f"Clipped DEM written to: {clipped_output}")
-    return clipped
+  os.makedirs(os.path.dirname(os.path.abspath(clipped_output)), exist_ok=True)
+  clipped.rio.to_raster(clipped_output)
+  print(f"Clipped DEM written to: {clipped_output}")
+  return clipped
 
 
 def get_clipped_path(output_file: str) -> str:
-    """Derive a default clipped output path from the raw DEM path."""
-    base, ext = os.path.splitext(output_file)
-    return base + "_clipped" + ext
+  """Derive a default clipped output path from the raw DEM path."""
+  base, ext = os.path.splitext(output_file)
+  return base + "_clipped" + ext
 
 
 if __name__ == "__main__":
-    args = setupArgs()
+  args = setupArgs()
 
-    output_file = os.path.abspath(args.outputFile)
-    geojson_file = os.path.abspath(args.geojson)
-    clipped_output = os.path.abspath(args.clippedOutputFile or get_clipped_path(output_file))
+  output_file = os.path.abspath(args.outputFile)
+  geojson_file = os.path.abspath(args.geojson)
+  clipped_output = os.path.abspath(args.clippedOutputFile or get_clipped_path(output_file))
 
-    if args.bounds is None:
-        bounds = bounds_from_geojson(geojson_file)
-        print(f"Bounding box automatically computed from GeoJSON: {bounds}")
-    else:
-        bounds = tuple(args.bounds)
+  if args.bounds is None:
+    bounds = bounds_from_geojson(geojson_file)
+    print(f"Bounding box automatically computed from GeoJSON: {bounds}")
+  else:
+    bounds = tuple(args.bounds)
 
-    # Download raw DEM
-    if args.skipDownload and os.path.exists(output_file):
-        print(f"Raw DEM already exists, skipping download: {output_file}")
-    else:
-        download_dem(bounds, output_file)
+  # Download raw DEM
+  if args.skipDownload and os.path.exists(output_file):
+    print(f"Raw DEM already exists, skipping download: {output_file}")
+  else:
+    download_dem(bounds, output_file)
 
-    if not os.path.exists(output_file):
-        raise RuntimeError(f"Expected DEM file not found after download: {output_file}")
+  if not os.path.exists(output_file):
+    raise RuntimeError(f"Expected DEM file not found after download: {output_file}")
 
-    # Clip to watershed boundary
-    print(f"Clipping DEM to boundary: {geojson_file}")
-    clip_dem_to_boundary(output_file, geojson_file, clipped_output)
+  # Clip to watershed boundary
+  print(f"Clipping DEM to boundary: {geojson_file}")
+  clip_dem_to_boundary(output_file, geojson_file, clipped_output)

--- a/scripts/dem_downloader.py
+++ b/scripts/dem_downloader.py
@@ -33,7 +33,7 @@ def setupArgs() -> argparse.Namespace:
     )
     parser.add_argument(
         "--outputFile",
-        default=DEFAULT_OUTPUT,
+        default=str(DEFAULT_OUTPUT),
         type=str,
         help=f"Output path for the raw (unclipped) DEM GeoTIFF. Default: {DEFAULT_OUTPUT}",
     )
@@ -47,12 +47,9 @@ def setupArgs() -> argparse.Namespace:
     )
     parser.add_argument(
         "--geojson",
-        default=DEFAULT_GEOJSON,
+        default=str(DEFAULT_GEOJSON),
         type=str,
-        help=(
-            "GeoJSON file defining the watershed boundary used to clip the DEM. "
-            f"Default: {DEFAULT_GEOJSON}"
-        ),
+        help=f"Path to a GeoJSON file used to spatially mask the data. Default: {DEFAULT_GEOJSON}",
     )
     parser.add_argument(
         "--skipDownload",
@@ -118,8 +115,8 @@ if __name__ == "__main__":
     clipped_output = os.path.abspath(args.clippedOutputFile or get_clipped_path(output_file))
 
     if args.bounds is None:
-        print("Bounding box automatically computed from GeoJSON.")
         bounds = bounds_from_geojson(geojson_file)
+        print(f"Bounding box automatically computed from GeoJSON: {bounds}")
     else:
         bounds = tuple(args.bounds)
 

--- a/scripts/dem_downloader.py
+++ b/scripts/dem_downloader.py
@@ -1,0 +1,137 @@
+import argparse
+import os
+from pathlib import Path
+
+import elevation
+import geopandas as gpd
+import rioxarray  # noqa: F401
+import xarray as xr
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = SCRIPT_DIR.parent
+DEFAULT_OUTPUT = PROJECT_ROOT / "data/GIS/SkagitRiver_90mDEM.tif"
+DEFAULT_GEOJSON = PROJECT_ROOT / "data/GIS/SkagitBoundary.json"
+
+
+def setupArgs() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Downloads an SRTM 90 m Digital Elevation Model (DEM) for a bounding box, "
+            "clips it to a watershed boundary, and saves the result as a GeoTIFF."
+        )
+    )
+    parser.add_argument(
+        "--bounds",
+        type=float,
+        nargs=4,
+        metavar=("MIN_LON", "MIN_LAT", "MAX_LON", "MAX_LAT"),
+        default=None,
+        help=(
+            "Bounding box for DEM download as four floats: minLon minLat maxLon maxLat. "
+            "If omitted, bounds are computed from --geojson."
+        ),
+    )
+    parser.add_argument(
+        "--outputFile",
+        default=DEFAULT_OUTPUT,
+        type=str,
+        help=f"Output path for the raw (unclipped) DEM GeoTIFF. Default: {DEFAULT_OUTPUT}",
+    )
+    parser.add_argument(
+        "--clippedOutputFile",
+        default=None,
+        type=str,
+        help=(
+            "Output path for the clipped DEM GeoTIFF. Defaults to <outputFile stem>_clipped.tif next to the outputFile."
+        ),
+    )
+    parser.add_argument(
+        "--geojson",
+        default=DEFAULT_GEOJSON,
+        type=str,
+        help=(
+            "GeoJSON file defining the watershed boundary used to clip the DEM. "
+            f"Default: {DEFAULT_GEOJSON}"
+        ),
+    )
+    parser.add_argument(
+        "--skipDownload",
+        action="store_true",
+        default=False,
+        help="Skip downloading a new DEM if the output file already exists.",
+    )
+    return parser.parse_args()
+
+
+def bounds_from_geojson(geojson_path: str, buffer_deg: float = 0.0) -> tuple[float, float, float, float]:
+    gdf = gpd.read_file(geojson_path)
+
+    # Ensure lon/lat degree bounds are interpreted consistently
+    if gdf.crs is None:
+        gdf = gdf.set_crs("EPSG:4326")
+    elif gdf.crs.to_string() != "EPSG:4326":
+        gdf = gdf.to_crs("EPSG:4326")
+
+    minx, miny, maxx, maxy = gdf.total_bounds
+    return (minx - buffer_deg, miny - buffer_deg, maxx + buffer_deg, maxy + buffer_deg)
+
+
+def download_dem(bounds: tuple[float, float, float, float], output_file: str) -> None:
+    """Download SRTM 90 m tiles for the given bounding box and merge into a single GeoTIFF."""
+    os.makedirs(os.path.dirname(os.path.abspath(output_file)), exist_ok=True)
+    print(f"Downloading SRTM 90 m DEM for bounds {bounds} -> {output_file}")
+    elevation.clip(bounds=bounds, output=output_file)
+    print("Download complete.")
+
+
+def clip_dem_to_boundary(dem_path: str, geojson_path: str, clipped_output: str) -> xr.DataArray:
+    """Open the DEM with rioxarray and clip it to the watershed polygon."""
+    boundary = gpd.read_file(geojson_path)
+    dem = rioxarray.open_rasterio(dem_path, masked=True)
+
+    # Ensure the boundary CRS matches the DEM CRS before clipping
+    if boundary.crs is None:
+        print("Warning: boundary GeoJSON has no CRS; assuming EPSG:4326.")
+        boundary = boundary.set_crs("EPSG:4326")
+    if dem.rio.crs is not None and boundary.crs != dem.rio.crs:
+        boundary = boundary.to_crs(dem.rio.crs)
+
+    clipped = dem.rio.clip(boundary.geometry)
+
+    os.makedirs(os.path.dirname(os.path.abspath(clipped_output)), exist_ok=True)
+    clipped.rio.to_raster(clipped_output)
+    print(f"Clipped DEM written to: {clipped_output}")
+    return clipped
+
+
+def get_clipped_path(output_file: str) -> str:
+    """Derive a default clipped output path from the raw DEM path."""
+    base, ext = os.path.splitext(output_file)
+    return base + "_clipped" + ext
+
+
+if __name__ == "__main__":
+    args = setupArgs()
+
+    output_file = os.path.abspath(args.outputFile)
+    geojson_file = os.path.abspath(args.geojson)
+    clipped_output = os.path.abspath(args.clippedOutputFile or get_clipped_path(output_file))
+
+    if args.bounds is None:
+        print("Bounding box automatically computed from GeoJSON.")
+        bounds = bounds_from_geojson(geojson_file)
+    else:
+        bounds = tuple(args.bounds)
+
+    # Download raw DEM
+    if args.skipDownload and os.path.exists(output_file):
+        print(f"Raw DEM already exists, skipping download: {output_file}")
+    else:
+        download_dem(bounds, output_file)
+
+    if not os.path.exists(output_file):
+        raise RuntimeError(f"Expected DEM file not found after download: {output_file}")
+
+    # Clip to watershed boundary
+    print(f"Clipping DEM to boundary: {geojson_file}")
+    clip_dem_to_boundary(output_file, geojson_file, clipped_output)


### PR DESCRIPTION
# Summary

This PR adds two new data downloader scripts to the repository. The scripts follow the CLI conventions of other downloader scripts, and retain but also generalize the functionality of the notebooks they were based on.

1. **CONUS404 Downloader** (`scripts/conus404_downloader.py`) - Downloads and processes CONUS404 gridded hydrologic data from USGS OSN
2. **DEM Downloader** (`scripts/dem_downloader.py`) - Downloads SRTM 90m Digital Elevation Model data and clips to watershed boundaries

This PR also updates the Pixi configuration and fixes the `data-download` environment name in `README.md`.

# Changes

## New Scripts

#### `scripts/conus404_downloader.py`
- Downloads CONUS404 data from USGS OSN public S3 endpoint
- Supports both daily and hourly temporal resolutions from the notebook and an additional monthly resolution
- Spatial masking using GeoJSON boundaries
- Computes derived meteorological variables (wind speed, total precipitation, vapor pressure, etc.)
- Date range subsetting with `--startDate` and `--endDate`
- Variable selection via `--parameters` argument
- Outputs chunked Zarr stores with filenames including date ranges

#### `scripts/dem_downloader.py`
- Downloads the SRTM 90m DEM tiles
- Auto-computes bounding box from GeoJSON boundary (when manual `--bounds` is not provided)
- Clips DEM to the provided GeoJSON boundary
- Outputs both raw and clipped GeoTIFF files
- Supports `--skipDownload` flag to reuse existing downloads

## Updated Files

#### `pixi.toml`
- Added `conus404` and `dem` tasks to the `data-download` environment
- Added `conus404-test` and `dem-test` test tasks
- Integrated new test tasks into `test-all-downloads`
- Updated dependencies:
  - Added `s3fs` - for S3 access to CONUS404 data
  - Added `regionmask` - for spatial masking operations
  - Added `elevation` - for SRTM DEM downloads
  - Added `virtualizarr` - for virtual Zarr handling
  - Updated `geopandas` - version bump from `>=0.9.0`

### `README.md`
- Fixed `data-download` environment name in Pixi installation instructions

# Notes

I made some local changes to the data downloader notebooks and considered pushing them here, as mentioned in a [PR](https://github.com/gaia-hazlab/gaia-data-downloaders/pull/9) in the gaia-data-downloaders repository. However, the goal here is to provide a sample data downloading script for the agent evaluation dataset, and updating the notebooks is out of scope. After discussing and considering that the notebooks are not actively used, I decided not to push those changes.